### PR TITLE
Refactor: Parallelize Company Search with a Dynamic Graph

### DIFF
--- a/src/core/agents/graph_builder.py
+++ b/src/core/agents/graph_builder.py
@@ -26,14 +26,29 @@ def build_resume_analysis_graph():
 
     # Use functools.partial to inject dependencies into the nodes
     workflow.add_node("parse_resume", partial(parse_resume_node, extractor=llm_extractor))
-    workflow.add_node("company_research", partial(search_company_info_node, template_service=template_service, model_name="gpt-4o"))
+    workflow.add_node("job_company_research", partial(search_company_info_node, 
+                                                      template_service=template_service, 
+                                                      branch="job_description",
+                                                      model_name="gpt-4.1-mini"))
+    workflow.add_node("resume_company_research", partial(search_company_info_node, 
+                                                         template_service=template_service, 
+                                                         branch="resume",
+                                                         model_name="gpt-4.1-mini"))
+
     workflow.add_node("parse_job_description", partial(parse_job_description_node, extractor=llm_extractor))
     workflow.add_node("experience_analyzer", partial(analyze_experience_node, extractor=llm_extractor))
-    # Connect nodes sequentially
+    
+    #### RESUME PATH ###
     workflow.add_edge(START, "parse_resume")
-    workflow.add_edge("parse_resume", "company_research")
-    workflow.add_edge("company_research", "parse_job_description")
-    workflow.add_edge("parse_job_description", "experience_analyzer")
+    workflow.add_edge("parse_resume", "resume_company_research")
+    
+    #### JOB DESCRIPTION PATH ###
+    workflow.add_edge(START, "parse_job_description")
+    workflow.add_edge("parse_job_description", "job_company_research")
+
+    #### ANALYSIS PATH ###
+    workflow.add_edge("resume_company_research", "experience_analyzer")
+    workflow.add_edge("job_company_research", "experience_analyzer")
     workflow.add_edge("experience_analyzer", END)
     
     # Compile and return the graph

--- a/src/core/agents/utils/nodes.py
+++ b/src/core/agents/utils/nodes.py
@@ -1,14 +1,18 @@
 import asyncio
-from typing import Dict, Optional
+from typing import Dict, Optional, Literal, List
 from langsmith import traceable
+import logging
+
 from src.core.agents.utils.state import AgentState
 from src.core.domain.resume import Resume
 from src.core.domain.job_description import JobDescription
-from src.core.domain.company_search import CompanySearchResponse
+from src.core.domain.company_search import CompanyInfo
 from src.infrastructure.components import llm_extractor
 from src.core.ports.secondary.llm_extractor import LLMExtractor
 from src.core.ports.secondary.template_service import TemplateService
 from src.core.agents.search_agents import search_company_info
+
+logger = logging.getLogger("core.agents.nodes")
 
 @traceable(run_type="llm")
 async def parse_resume_node(state: AgentState, extractor: LLMExtractor):
@@ -33,14 +37,20 @@ async def parse_job_description_node(state: AgentState, extractor: LLMExtractor)
 @traceable(run_type="tool")
 async def search_company_info_node(state: AgentState, 
                                    template_service: TemplateService, 
-                                   model_name="gpt-4o") -> Dict[str, Optional[CompanySearchResponse]]:
-    """
-    Search for information about a company and return structured data.
-    """
-    company_names = [experience.company for experience in state["resume"].experiences]
+                                   branch: Literal["resume", "job_desription"] = "job_description",
+                                   model_name="gpt-4.1-mini") -> Dict[str, Optional[CompanyInfo]]:
+    if branch == "resume":
+        companies = state["resume"].company_names
+    elif branch == "job_description":
+        companies = [state["job_description"].company_name]
+    else:
+        raise ValueError("This branch is not supported.")
+    
+    tasks = [search_company_info(company_name=company_name, 
+                                 model_name=model_name, 
+                                 template_service=template_service) for company_name in companies]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    results = {result.name: result for result in results if isinstance(result, CompanyInfo)}
+    logger.info(f"Retrieved information for branch {branch} with length {len(results)} companies.")
 
-    tasks = [search_company_info(company, template_service, model_name) for company in company_names]
-    results = await asyncio.gather(*tasks)
-    company_info_list = [result for result in results if result is not None]
-    print(f"Retrieved information for {len(company_info_list)} out of {len(company_names)} companies.")
-    return {"company_info": company_info_list}
+    return {f"{branch}_company_info": results}

--- a/src/core/agents/utils/state.py
+++ b/src/core/agents/utils/state.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, TypedDict, Dict
 
-from src.core.domain.company_search import CompanySearchResponse
+from src.core.domain.company_search import CompanyInfo
 from src.core.domain.resume import Resume
 from src.core.domain.job_description import JobDescription
 from src.core.domain.resume_match import (
@@ -25,7 +25,8 @@ class AgentState(TypedDict):
     job_description: JobDescription
     
     # Enriched data
-    company_info: Optional[Dict[str, CompanySearchResponse]]
+    resume_company_info: Optional[Dict[str, CompanyInfo]]
+    job_description_company_info: Optional[Dict[str, CompanyInfo]]
     
     # Analysis results (populated by agents)
     skill_matches: Optional[List[SkillMatch]]

--- a/src/core/domain/company_search.py
+++ b/src/core/domain/company_search.py
@@ -1,17 +1,17 @@
 from pydantic import BaseModel, Field
 from typing import Optional
 
-class CompanySearchResponse(BaseModel):
-    company_name: str = Field(description="The name of the company")
-    company_description: Optional[str] = Field(None, description="A description of the company") 
-    company_website: Optional[str] = Field(None, description="The website of the company")
-    company_location: Optional[str] = Field(None, description="The location of the company")
-    company_industry: Optional[str] = Field(None, description="The industry of the company")
-    company_size: Optional[int] = Field(None, description="The approximate number of employees at the company")
-    company_revenue: Optional[str] = Field(None, description="The annual revenue of the company")
+class CompanyInfo(BaseModel):
+    name: str = Field(description="The name of the company")
+    description: Optional[str] = Field(None, description="A description of the company") 
+    website: Optional[str] = Field(None, description="The website of the company")
+    location: Optional[str] = Field(None, description="The location of the company")
+    industry: Optional[str] = Field(None, description="The industry of the company")
+    size: Optional[int] = Field(None, description="The approximate number of employees at the company")
+    revenue: Optional[str] = Field(None, description="The annual revenue of the company")
     founded_year: Optional[int] = Field(None, description="The year the company was founded")
 
 
 if __name__ == "__main__":
-    data_model = CompanySearchResponse.model_json_schema()
+    data_model = CompanyInfo.model_json_schema()
     print(data_model)

--- a/src/core/domain/resume.py
+++ b/src/core/domain/resume.py
@@ -99,3 +99,7 @@ class Resume(BaseModel):
             return cls.model_validate_json(json_str)
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON string: {str(e)}")
+
+    @property
+    def company_names(self) -> List[str]:
+        return [experience.company for experience in self.experiences]


### PR DESCRIPTION
### **Refactor: Parallelize Company Search with a Dynamic Graph**

#### **Description**

Primary change is the parallelization of the company information search process, which was previously a sequential and blocking operation.

The LangGraph has been restructured from a linear chain into a parallel graph. Now, the resume and job description are processed in separate, concurrent branches. Each branch fans out to perform company research in parallel for all companies found, and the results are then joined before the final analysis step.

#### **Key Changes**

*   **Parallel Graph Execution:**
    *   The `build_resume_analysis_graph` now defines a parallel structure where resume parsing and job description parsing are initiated simultaneously.
    *   Two distinct nodes, `resume_company_research` and `job_company_research`, are created from the same underlying function, each handling a different branch of the state.

*   **Concurrent Fan-Out Search:**
    *   The `search_company_info_node` has been refactored to take a `branch` parameter (`"resume"` or `"job_description"`).
    *   Inside the node, `asyncio.gather` is now used to execute a web search for every company found in the source document *concurrently*.
    *   This node is now robust against failures; using `return_exceptions=True`, it ensures that a single failed search doesn't terminate the entire process.

*   **State and Data Model Updates:**
    *   `AgentState` was updated to store company information from the two branches separately in `resume_company_info` and `job_description_company_info`.
    *   The Pydantic model `CompanySearchResponse` was renamed to the more generic `CompanyInfo`, and its field names (`company_name` -> `name`, etc.) were simplified for broader use.
    *   The `Resume` model now includes a `company_names` property for easier access.