### PR TITLE
Add model override capability

### DIFF
--- a/src/core/domain/config.py
+++ b/src/core/domain/config.py
@@ -43,10 +43,22 @@ class TemplateConfig:
 
 @dataclass
 class AIProviderConfig:
-    model_name: str = "gpt-4o"
+    """Base configuration for AI providers with common settings."""
     temperature: float = 0.1
     max_tokens: Optional[int] = None
 
 @dataclass
 class OpenAIConfig(AIProviderConfig):
+    """OpenAI-specific configuration."""
+    model_name: str = "gpt-4o"
     api_version: str = "2024-02-15"
+
+@dataclass
+class AnthropicConfig(AIProviderConfig):
+    """Anthropic-specific configuration."""
+    model_name: str = "claude-3-sonnet-20240229"
+
+@dataclass
+class GeminiConfig(AIProviderConfig):
+    """Gemini-specific configuration."""
+    model_name: str = "gemini-1.5-pro"

--- a/src/core/domain/config.py
+++ b/src/core/domain/config.py
@@ -56,9 +56,9 @@ class OpenAIConfig(AIProviderConfig):
 @dataclass
 class AnthropicConfig(AIProviderConfig):
     """Anthropic-specific configuration."""
-    model_name: str = "claude-3-sonnet-20240229"
+    model_name: str = "claude-3.5-sonnet-20241022"
 
 @dataclass
 class GeminiConfig(AIProviderConfig):
     """Gemini-specific configuration."""
-    model_name: str = "gemini-1.5-pro"
+    model_name: str = "gemini-2.5-pro"

--- a/src/core/ports/secondary/ai_provider.py
+++ b/src/core/ports/secondary/ai_provider.py
@@ -1,14 +1,32 @@
 from dataclasses import dataclass
-from typing import Protocol, Optional, List
+from typing import Protocol, Optional, List, Union
+from abc import ABC, abstractmethod
 
 @dataclass
 class AIOptions:
+    """Generic AI options that are common across all providers."""
     temperature: float = 0.1
     max_tokens: Optional[int] = None
     stop_sequences: Optional[List[str]] = None
 
+@dataclass
+class OpenAIOptions(AIOptions):
+    """OpenAI-specific options including model selection."""
+    model: Optional[str] = None
+
+@dataclass
+class AnthropicOptions(AIOptions):
+    """Anthropic-specific options including model selection."""
+    model: Optional[str] = None
+
+@dataclass
+class GeminiOptions(AIOptions):
+    """Gemini-specific options including model selection."""
+    model: Optional[str] = None
 
 class AIProvider(Protocol):
+    """Base protocol for AI providers."""
+    
     async def complete(self, prompt: str, 
                        prompt_specific_options: Optional[AIOptions] = None) -> str:
         """Generate completion for the given prompt"""

--- a/src/infrastructure/ai_providers/anthropic_provider.py
+++ b/src/infrastructure/ai_providers/anthropic_provider.py
@@ -1,0 +1,64 @@
+from typing import Optional
+import os
+from dotenv import load_dotenv
+from langsmith import traceable
+from src.core.ports.secondary.ai_provider import AIProvider, AIOptions, AnthropicOptions
+from src.infrastructure.ai_providers.exceptions import AIProviderError
+from src.core.domain.config import AnthropicConfig
+
+class AnthropicProvider(AIProvider):
+    """Anthropic implementation of the AI provider interface."""
+    
+    def __init__(self, config: AnthropicConfig):
+        """
+        Initialize Anthropic provider with API key and global options.
+        
+        :param config: Configuration for Anthropic provider containing global options
+        :type config: AnthropicConfig
+        :raises AIProviderError: If API key is not provided or found in environment
+        """
+        load_dotenv()
+        self.api_key = os.getenv("ANTHROPIC_API_KEY")
+        if not self.api_key:
+            raise AIProviderError("Anthropic API key not found. Set ANTHROPIC_API_KEY environment variable.")
+            
+        try:
+            # TODO: Initialize Anthropic client when implementing
+            pass
+        except Exception as e:
+            raise AIProviderError(f"Failed to initialize Anthropic client: {str(e)}")
+            
+        self.global_options = AnthropicOptions(
+            temperature=config.temperature,
+            max_tokens=config.max_tokens,
+            model=config.model_name
+        )
+        self.default_model = config.model_name
+
+    @traceable(run_type="llm")
+    async def complete(self, prompt: str, 
+                       prompt_specific_options: Optional[AIOptions] = None) -> str:
+        """
+        Generate completion using Anthropic API.
+        
+        :param prompt: Input prompt
+        :type prompt: str
+        :param prompt_specific_options: Options specific to this prompt call, overrides global options if provided
+        :type prompt_specific_options: AIOptions
+        :return: Generated completion text
+        :rtype: str
+        :raises AIProviderError: If API call fails.
+        """
+        # Use prompt-specific options if provided, otherwise use global options
+        options_to_use = prompt_specific_options if prompt_specific_options else self.global_options
+        
+        # Determine which model to use
+        model_to_use = self.default_model
+        if isinstance(options_to_use, AnthropicOptions) and options_to_use.model:
+            model_to_use = options_to_use.model
+        
+        try:
+            # TODO: Implement actual Anthropic API call
+            raise NotImplementedError("Anthropic provider not yet implemented")
+        except Exception as e:
+            raise AIProviderError(f"Anthropic API error: {str(e)}")

--- a/src/infrastructure/ai_providers/gemini_provider.py
+++ b/src/infrastructure/ai_providers/gemini_provider.py
@@ -1,0 +1,64 @@
+from typing import Optional
+import os
+from dotenv import load_dotenv
+from langsmith import traceable
+from src.core.ports.secondary.ai_provider import AIProvider, AIOptions, GeminiOptions
+from src.infrastructure.ai_providers.exceptions import AIProviderError
+from src.core.domain.config import GeminiConfig
+
+class GeminiProvider(AIProvider):
+    """Gemini implementation of the AI provider interface."""
+    
+    def __init__(self, config: GeminiConfig):
+        """
+        Initialize Gemini provider with API key and global options.
+        
+        :param config: Configuration for Gemini provider containing global options
+        :type config: GeminiConfig
+        :raises AIProviderError: If API key is not provided or found in environment
+        """
+        load_dotenv()
+        self.api_key = os.getenv("GOOGLE_API_KEY")
+        if not self.api_key:
+            raise AIProviderError("Google API key not found. Set GOOGLE_API_KEY environment variable.")
+            
+        try:
+            # TODO: Initialize Google AI client when implementing
+            pass
+        except Exception as e:
+            raise AIProviderError(f"Failed to initialize Gemini client: {str(e)}")
+            
+        self.global_options = GeminiOptions(
+            temperature=config.temperature,
+            max_tokens=config.max_tokens,
+            model=config.model_name
+        )
+        self.default_model = config.model_name
+
+    @traceable(run_type="llm")
+    async def complete(self, prompt: str, 
+                       prompt_specific_options: Optional[AIOptions] = None) -> str:
+        """
+        Generate completion using Gemini API.
+        
+        :param prompt: Input prompt
+        :type prompt: str
+        :param prompt_specific_options: Options specific to this prompt call, overrides global options if provided
+        :type prompt_specific_options: AIOptions
+        :return: Generated completion text
+        :rtype: str
+        :raises AIProviderError: If API call fails.
+        """
+        # Use prompt-specific options if provided, otherwise use global options
+        options_to_use = prompt_specific_options if prompt_specific_options else self.global_options
+        
+        # Determine which model to use
+        model_to_use = self.default_model
+        if isinstance(options_to_use, GeminiOptions) and options_to_use.model:
+            model_to_use = options_to_use.model
+        
+        try:
+            # TODO: Implement actual Gemini API call
+            raise NotImplementedError("Gemini provider not yet implemented")
+        except Exception as e:
+            raise AIProviderError(f"Gemini API error: {str(e)}")

--- a/src/infrastructure/ai_providers/mock_provider.py
+++ b/src/infrastructure/ai_providers/mock_provider.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Dict, Any
 import os
 import json
-from src.core.ports.secondary.ai_provider import AIProvider, AIOptions
+from src.core.ports.secondary.ai_provider import AIProvider, AIOptions, OpenAIOptions
 from src.core.domain.config import AIProviderConfig
 from langsmith import traceable
 
@@ -15,11 +15,12 @@ class MockAIProvider(AIProvider):
         :param config: Configuration for AI provider containing global options
         :type config: AIProviderConfig
         """
-        self.global_options = AIOptions(
+        self.global_options = OpenAIOptions(
             temperature=config.temperature,
-            max_tokens=config.max_tokens
+            max_tokens=config.max_tokens,
+            model=getattr(config, 'model_name', 'mock-model')
         )
-        self.model_name = config.model_name
+        self.default_model = getattr(config, 'model_name', 'mock-model')
         self.responses = {}  # Can be populated with predefined responses for testing
         self.default_structured_responses = {
             # Default response for experience alignment

--- a/src/infrastructure/ai_providers/mock_provider.py
+++ b/src/infrastructure/ai_providers/mock_provider.py
@@ -21,7 +21,7 @@ class MockAIProvider(AIProvider):
             model=getattr(config, 'model_name', 'mock-model')
         )
         self.default_model = getattr(config, 'model_name', 'mock-model')
-        self.responses = {}  # Can be populated with predefined responses for testing
+        self.responses: Dict[str, str] = {}  # Can be populated with predefined responses for testing
         self.default_structured_responses = {
             # Default response for experience alignment
             "experience_analyzer": json.dumps({
@@ -34,7 +34,7 @@ class MockAIProvider(AIProvider):
         }
 
     @traceable(run_type="llm")
-    async def complete(self, prompt: str, prompt_specific_options: AIOptions = None) -> str:
+    async def complete(self, prompt: str, prompt_specific_options: Optional[AIOptions] = None) -> str:
         """
         Mock completion that returns predefined responses or a default response.
         

--- a/src/infrastructure/components.py
+++ b/src/infrastructure/components.py
@@ -4,7 +4,7 @@ from src.core.ports.secondary.template_service import TemplateService
 from src.infrastructure.ai_providers.openai_provider import OpenAIProvider
 from src.infrastructure.ai_providers.mock_provider import MockAIProvider
 from src.infrastructure.template.jinja_template_service import JinjaTemplateService
-from src.core.domain.config import AIProviderConfig, TemplateConfig
+from src.core.domain.config import AIProviderConfig, OpenAIConfig, TemplateConfig
 from src.infrastructure.extractors.llm_extractor import LLMStructuredExtractor
 
 def create_ai_provider() -> AIProvider:
@@ -14,13 +14,13 @@ def create_ai_provider() -> AIProvider:
     :return: An implementation of AIProvider
     :rtype: AIProvider
     """
-    config = AIProviderConfig()
-    
     # Use MockAIProvider for testing environment
     if os.getenv("TESTING", "false").lower() == "true":
+        config = AIProviderConfig()
         return MockAIProvider(config=config)
     
     # Use OpenAIProvider for production
+    config = OpenAIConfig()
     return OpenAIProvider(config=config)
 
 def create_template_service() -> TemplateService:

--- a/tests/infrastructure/extractors/test_llm_extractor.py
+++ b/tests/infrastructure/extractors/test_llm_extractor.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch, MagicMock
 
 from src.infrastructure.ai_providers.openai_provider import OpenAIProvider
-from src.core.domain.config import AIProviderConfig, TemplateConfig
+from src.core.domain.config import AIProviderConfig, OpenAIConfig, TemplateConfig
 from src.infrastructure.template.jinja_template_service import JinjaTemplateService
 from src.core.domain.resume import Resume
 from src.infrastructure.extractors.llm_extractor import LLMStructuredExtractor
@@ -124,7 +124,7 @@ async def test_llm_extractor_resume_parse(mock_openai_setup):
     :type mock_openai_setup: MagicMock
     :raises AssertionError: If the parsing fails or returns unexpected results
     """
-    ai_config = AIProviderConfig()
+    ai_config = OpenAIConfig()
     template_config = TemplateConfig.development()
     
     # Create extractor with correct parameters (no output_model)


### PR DESCRIPTION
## Summary
Refactored the AI provider system to support model selection per request while maintaining backward compatibility. Added templates for Anthropic and Gemini providers.

## Changes

### Core Updates
- Added provider-specific options classes (`OpenAIOptions`, `AnthropicOptions`, `GeminiOptions`) with model override capability
- Restructured config classes to separate common settings from provider-specific ones
- Updated OpenAI provider to support model override per request
- Fixed component factory to use correct config types

### New Provider Templates
- Created `AnthropicProvider` template with `ANTHROPIC_API_KEY` support (Future integration)
- Created `GeminiProvider` template with `GOOGLE_API_KEY` support (Future integration)

## Usage
```python
# Model override per request
options = OpenAIOptions(model="gpt-4.1", temperature=0.7)
response = await provider.complete("Hello!", prompt_specific_options=options)
```